### PR TITLE
Make sure keyboard uses return key on multiline

### DIFF
--- a/src/components/Merlin.js
+++ b/src/components/Merlin.js
@@ -153,7 +153,7 @@ export default forwardRef(
                 onEndEditing: () =>
                   validateOnBlur &&
                   validate(child.props, values[child.props.name], values),
-                returnKeyType: getReturnKeyType(inputs, child.props.name),
+                returnKeyType: getReturnKeyType(inputs, child.props.name, child.props.multiline),
                 blurOnSubmit: false,
                 key: child.props.name,
                 error: errors[child.props.name],

--- a/src/lib/inputs.js
+++ b/src/lib/inputs.js
@@ -13,8 +13,11 @@ export const parseInputs = (children) =>
 export const getInputPosition = (inputs, name) =>
   inputs.findIndex((input) => input.props.name === name)
 
-export const getReturnKeyType = (inputs, name) => {
+export const getReturnKeyType = (inputs, name, multiline) => {
   const inputPosition = getInputPosition(inputs, name)
+  if (multiline) {
+    return 'default';
+  }
   const isLastInput = inputPosition === inputs.length - 1
   return isLastInput ? 'done' : 'next'
 }


### PR DESCRIPTION
## Steps to reproduce:

1. Create a multiline styled text input inside a Merlin form
2. Tap into the field

## What I saw:
A 'next' button, which when pressed entered a carriage return into the multiline text box.

## What I expected:
The default return button.

## Screenshot with fix applied:

<img width="394" alt="Screenshot 2020-07-19 at 21 38 02" src="https://user-images.githubusercontent.com/47539/87884746-7b92f880-ca08-11ea-8eee-fe472f6f2c61.png">
