### PR TITLE
Added ability to manually set returnKeyType, with warning when you do so

### DIFF
--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -20,12 +20,18 @@ const Input = ({
   instantValidation = false,
   name,
   onSubmitEditing,
+  returnKeyType,
+  suppressReturnKeyTypeWarning = false,
   ...passThrough
 }) => {
   const ref = useRef(null)
   const { values, setValues, setErrors, errors, inputs, shouldRecalculate, addInput, registerInput } = useForm(
     'Form.Input'
   )
+
+  if (returnKeyType && !suppressReturnKeyTypeWarning) {
+    console.warn("A form input has been supplied a returnKeyType, but react-native-merlin handles these automatically. You can suppress this warning by passing suppressReturnKeyTypeWarning to the input component.")
+  }
 
   const onEvent = v => {
     let value = parseValue ? parseValue(v) : v
@@ -55,7 +61,7 @@ const Input = ({
 
   useEffect(addInput, [])
 
-  const returnKeyType = useMemo(() => {
+  const autoReturnKeyType = useMemo(() => {
     return getReturnKeyType(inputs, name, multiline)
   }, [inputs, name, multiline])
 
@@ -75,8 +81,8 @@ const Input = ({
     [valueKey]: get(values, name) || undefined,
     error: errors?.[name] || undefined,
     ...(multiline && { multiline }),
-    returnKeyType,
-    onSubmitEditing: e => {
+    returnKeyType: returnKeyType || autoReturnKeyType,
+    onSubmitEditing: (e) => {
       tryFocusNextInput(e)
       onSubmitEditing && onSubmitEditing(e)
     },


### PR DESCRIPTION
This just lets you override the `returnKeyType` set by merlin, for situations where you want a little more control over their behaviour.

It's likely that people will use this without actually realising there is a built-in solution so there is an attached warning which can be supressed with `suppressReturnKeyTypeWarning`:

> A form input has been supplied a returnKeyType, but react-native-merlin handles these automatically. You can suppress this warning by passing suppressReturnKeyTypeWarning to the input component.