### PR TITLE
Fix issue where validating a field with an object as a value would result in an error being falsely reported

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -49,7 +49,9 @@ const Form = forwardRef(
     }, [_errors])
 
     const validateAllFields = values => {
-      const errors = inputs.map(input => validate(input, get(values, input.name), values)).filter(v => v !== true)
+      const errors = inputs
+        .map((input) => validate(input, get(values, input.name), values))
+        .filter((v) => (v?.error ? v.error !== true : v !== true))
 
       const errorsMappedToNames = errors.reduce((errors, item) => {
         errors[item.name] = item.error


### PR DESCRIPTION
When filtering fields by validity, values that were returned as objects returned their value slightly differently, and would result in a false negative by the validator.

```
// Typical validator value
true

// Validator value when input is an object
{"error": true, "name": "exampleFieldName"}
```

This just tweaks the filter to check for objects